### PR TITLE
Wip renew enable service script

### DIFF
--- a/scripts/agora_script_base.class.php
+++ b/scripts/agora_script_base.class.php
@@ -10,14 +10,21 @@ class agora_script_base{
 		return $params;
 	}
 
-	function execute() {
+	function execute($params = false) {
 		if ($this->can_be_executed()) {
 			$starttime = microtime();
 
 			echo $this->title."\n";
 
-			$params = $this->get_request_params();
-			$return  = $this->_execute($params);
+            if (!$params) {
+                $params = $this->get_request_params();
+            }
+
+            try {
+				$return = $this->_execute($params);
+			} catch (Exception $e) {
+				echo $e->getMessage();
+			}
 
 			$difftime = self::microtime_diff($starttime, microtime());
 
@@ -52,4 +59,31 @@ class agora_script_base{
 	protected function can_be_executed($params = array()) {
 		return true;
 	}
+
+        protected function output($message, $type = "") {
+        if (is_object($message) || is_array($message)) {
+            print_r($message);
+            return;
+        }
+
+        if (!empty($type)) {
+            $message = $type.': '.$message;
+        }
+        echo $message."\n";
+        return;
+    }
+
+    protected function execute_suboperation($function, $params = array()) {
+        $function = 'script_'.$function;
+        $filename = $function.'.class.php';
+        $basedir = dirname(__FILE__).'/';
+        if (!file_exists($basedir.$filename)) {
+            $this->output("File $basedir $filename does not exists", 'ERROR');
+            return false;
+        }
+        require_once($filename);
+        $script = new $function();
+        return $script->execute($params);
+    }
+
 }

--- a/scripts/script_enable_service.class.php
+++ b/scripts/script_enable_service.class.php
@@ -43,7 +43,9 @@ class script_enable_service extends agora_script_base {
         $dbModels = explode(',', $params['DBNodesModel']);
 
         update_option('blogname', $clientName);
-        update_option('blogdescription', 'Espai del centre ' . $clientName);
+
+        // Don't change default blog description
+        //update_option('blogdescription', 'Espai del centre ' . $clientName);
 
         $siteURL = WP_SITEURL;
         update_option('siteurl', $siteURL);


### PR DESCRIPTION
Aquests canvis equivalen a https://github.com/projectestac/agora/commit/8e85de6a119c6978653bb99d2ea5e071013b3e13 i  també arreglen els replaces que feia l'script: ara és protocol independant per exemple.

Caldria revisar que totes les maquetes generen una bd vàlida per nodes i que a més, fent un export i un grep no es troben resultats usu\* ni master\* a la SQL resultant.

Per provar aquesta branca és necessari també integrar aquesta WIP-enable_service_script (no faig pull request però s'ha d'integrar també).
